### PR TITLE
feat: Update project version and add Codecov integration

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -192,14 +192,12 @@ jobs:
         run: |
           echo "::error::Release Badging failed, please update badging with: ./gradlew updateReleaseBadging" && exit 1
 
-
         # Runs if previous job failed
       - name: Generate new release badging if verification failed and it's a PR
         id: generate_badging
-        if: steps.checkfork_badging.outcome == 'failure' && github.event_name == 'pull_request'
+        if: steps.badging_verify.outcome == 'failure' && github.event_name == 'pull_request'
         run: |
           ./gradlew updateProdReleaseBadging
-
 
       - name: Push new release badging if available
         uses: stefanzweifel/git-auto-commit-action@v5
@@ -316,3 +314,11 @@ jobs:
           compression-level: 1
           overwrite: false
           path: '**/build/reports/jacoco/'
+
+      - name: Upload Test Report
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          verbose: true
+          files: ${{ github.workspace }}/**/build/reports/jacoco/**/*Report.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/cache_cleanup.yaml
+++ b/.github/workflows/cache_cleanup.yaml
@@ -1,4 +1,4 @@
-name: cleanup caches by a branch
+name: Cache Cleanup
 on:
   pull_request:
     types:
@@ -6,14 +6,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  cleanup:
+  cleanup_pr:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Cleanup
+      - name: Cleanup PR Cache
         run: |
           gh extension install actions/gh-actions-cache
 
-          echo "Fetching list of cache key"
+          echo "Fetching list of cache keys"
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
 
           ## Setting this to not fail the workflow while deleting cache keys.
@@ -28,3 +29,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+
+  cleanup_all:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup All Caches
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          echo "Fetching list of all cache keys"
+          allCacheKeys=$(gh actions-cache list -R $REPO | cut -f 1)
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting all caches..."
+          for cacheKey in $allCacheKeys
+          do
+              gh actions-cache delete $cacheKey -R $REPO --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@
  *
  */
 import com.niyaj.samples.apps.popos.PoposBuildType
+import com.niyaj.samples.apps.popos.cleanedVersion
 
 plugins {
     alias(libs.plugins.popos.android.application)
@@ -39,7 +40,7 @@ android {
 
     defaultConfig {
         applicationId = libs.versions.namespace.get()
-        versionName = project.version.toString()
+        versionName = project.cleanedVersion
         versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
         testInstrumentationRunner = "com.niyaj.testing.PoposTestRunner"
 

--- a/app/prodRelease-badging.txt
+++ b/app/prodRelease-badging.txt
@@ -1,4 +1,4 @@
-package: name='com.niyaj.poposroom' versionCode='1' versionName='1.0.1-alpha.0.5' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
+package: name='com.niyaj.poposroom' versionCode='1' versionName='0.0.1-beta.0.1' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
 sdkVersion:'26'
 targetSdkVersion:'34'
 uses-permission: name='android.permission.FOREGROUND_SERVICE'

--- a/app/prodRelease-badging.txt
+++ b/app/prodRelease-badging.txt
@@ -1,4 +1,4 @@
-package: name='com.niyaj.poposroom' versionCode='1' versionName='1.0.0-alpha.5.473+20240909T204119Z' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
+package: name='com.niyaj.poposroom' versionCode='1' versionName='1.0.1-alpha.0.5' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
 sdkVersion:'26'
 targetSdkVersion:'34'
 uses-permission: name='android.permission.FOREGROUND_SERVICE'

--- a/build-logic/convention/src/main/kotlin/com/niyaj/samples/apps/popos/ProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/niyaj/samples/apps/popos/ProjectExtensions.kt
@@ -20,3 +20,6 @@ inline fun Project.spotlessGradle(crossinline configure: SpotlessExtension.() ->
     extensions.configure<SpotlessExtension> {
         configure()
     }
+
+val Project.cleanedVersion: String
+    get() = this.version.toString().split('+')[0]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,8 @@ tasks.register("printModulePaths") {
 
 object DynamicVersion {
     fun setDynamicVersion(file: File, version: String) {
-        file.writeText(version)
+        val cleanedVersion = version.split('+')[0]
+        file.writeText(cleanedVersion)
     }
 }
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+{
+  "fixes": [
+    "/home/runner/work/PoposRoom/PoposRoom>/::"
+  ],
+  "codecov": {
+    "disable_default_path_fixes": true
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,3 @@
-import org.ajoberstar.reckon.core.Scope
-import org.ajoberstar.reckon.gradle.ReckonExtension
-
 /*
  *      Copyright 2024 Sk Niyaj Ali
  *
@@ -16,6 +13,8 @@ import org.ajoberstar.reckon.gradle.ReckonExtension
  *      See the License for the specific language governing permissions and
  *      limitations under the License.
  */
+
+import org.ajoberstar.reckon.gradle.ReckonExtension
 
 pluginManagement {
     includeBuild("build-logic")
@@ -41,8 +40,7 @@ plugins {
 
 extensions.configure<ReckonExtension> {
     setDefaultInferredScope("patch")
-    stages("alpha","beta","final")
-    setScopeCalc { java.util.Optional.of(Scope.PATCH) }
+    stages("beta", "final")
     setScopeCalc(calcScopeFromProp().or(calcScopeFromCommitMessages()))
     setStageCalc(calcStageFromProp())
     setTagWriter { it.toString() }


### PR DESCRIPTION
This commit updates the project version to 1.0.1-alpha.0.5 and removes
 the timestamp from the version name. It also adds Codecov integration for test coverage reporting.

The cache cleanup workflow is renamed to "Cache Cleanup" and split into two jobs: `cleanup_pr` and `cleanup_all`. The `cleanup_pr` job cleans up caches for pull requests, while the ` cleanup_all` job cleans up all caches when triggered manually.

The build workflow is updated to include a step for uploading test reports to Codecov.

Additionally, the `cleanedVersion` property is added to the project extensions to provide the version name without the timestamp.