### PR TITLE
CI: Trigger internal and beta releases from main branch

### DIFF
--- a/.github/actions/create-release-notes/action.yml
+++ b/.github/actions/create-release-notes/action.yml
@@ -49,8 +49,8 @@ runs:
         echo "Full Changelog:"
         CHANGELOG="${{ steps.generate-notes.outputs.result }}"
         echo -e "$CHANGELOG"
-        printf "$CHANGELOG" > ./app/build/outputs/changelogGithub
+        printf "$CHANGELOG" > ./app/build/outputs/changelogGithub.md
 
         echo "Beta Changelog:"
         git log --format="* %s" HEAD^..HEAD
-        git log --format="* %s" HEAD^..HEAD > ./app/build/outputs/changelogBeta
+        git log --format="* %s" HEAD^..HEAD > ./app/build/outputs/changelogBeta.md

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -1,8 +1,6 @@
 name: Build and Test
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
 
 concurrency:
@@ -159,6 +157,7 @@ jobs:
           path: |
             **/build/reports/lint-results-*.html
             **/build/test-results/test*UnitTest/**.xml
+
 
 
 

--- a/.github/workflows/internal_or_beta_release.yml
+++ b/.github/workflows/internal_or_beta_release.yml
@@ -17,8 +17,8 @@ on:
         required: false
         default: false
   push:
-    tags:
-      - '[0-9][0-9][0-9][0-9].[0-9][0-9].0'
+    branches:
+      - main
 
 jobs:
   app_build:
@@ -127,7 +127,7 @@ jobs:
           tag_name: ${{ steps.rel_number.outputs.version }}
           draft: false
           prerelease: true
-          body: ${{ steps.build_changelog.outputs.changelog }}
+          body_path: ./app/build/outputs/changelogGithub.md
           files: |
             ./app/build/outputs/apk/demo/release/app-demo-release.apk
             ./app/build/outputs/apk/prod/release/app-prod-release.apk
@@ -166,7 +166,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
-        run: ./gradlew appDistributionUploadFullRelease
+        run: ./gradlew appDistributionUploadFullRelease --no-configuration-cache
 
       - name: 🤖 Prepare Amazon Listing
         if: github.event.inputs.release_type == 'beta' && github.event.inputs.amazon == 'true'
@@ -182,7 +182,7 @@ jobs:
         uses: stefanzweifel/changelog-updater-action@v1
         with:
           latest-version: ${{ steps.rel_number.outputs.version }}
-          release-notes: ${{ steps.build_changelog.outputs.changelog }}
+          release-notes: ./app/build/outputs/changelogGithub.md
 
       - name: 🤖 Commit CHANGELOG.md
         if: steps.update_changelog.outcome == 'success'

--- a/.github/workflows/monthly_release.yaml
+++ b/.github/workflows/monthly_release.yaml
@@ -1,4 +1,4 @@
-name: Bump our Calendar Version
+name: Monthly Release
 
 on:
   workflow_dispatch:

--- a/app/prodRelease-badging.txt
+++ b/app/prodRelease-badging.txt
@@ -1,4 +1,4 @@
-package: name='com.niyaj.poposroom' versionCode='1' versionName='0.0.1-beta.0.1' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
+package: name='com.niyaj.poposroom' versionCode='1' versionName='2024.9.1-beta.0.0' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
 sdkVersion:'26'
 targetSdkVersion:'34'
 uses-permission: name='android.permission.FOREGROUND_SERVICE'

--- a/app/prodRelease-badging.txt
+++ b/app/prodRelease-badging.txt
@@ -1,4 +1,4 @@
-package: name='com.niyaj.poposroom' versionCode='1' versionName='2024.9.1-beta.0.0' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
+package: name='com.niyaj.poposroom' versionCode='1' versionName='0.0.1-beta.0.1' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
 sdkVersion:'26'
 targetSdkVersion:'34'
 uses-permission: name='android.permission.FOREGROUND_SERVICE'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,7 +41,7 @@ plugins {
 extensions.configure<ReckonExtension> {
     setDefaultInferredScope("patch")
     stages("beta", "final")
-    setScopeCalc(calcScopeFromProp().or(calcScopeFromCommitMessages()))
+    setScopeCalc { java.util.Optional.of(org.ajoberstar.reckon.core.Scope.PATCH) }
     setStageCalc(calcStageFromProp())
     setTagWriter { it.toString() }
 }


### PR DESCRIPTION
This commit updates the CI workflow to trigger internal and beta releases from the main branch instead of using tags.

The changelog is now generated and stored in `changelogGithub.md` and `changelogBeta.md` files.

The `appDistributionUploadFullRelease` task is executed with the `--no-configuration-cache` option.

The `reckon` extension is configured to always use `PATCH` scope .