### PR TITLE
Fix: Use correct release notes file extension for Firebase App Distri…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,7 +104,7 @@ android {
 
     firebaseAppDistribution {
         serviceCredentialsFile = "app/firebaseAppDistributionServiceCredentialsFile.json"
-        releaseNotesFile = "./app/build/outputs/changelogBeta"
+        releaseNotesFile = "./app/build/outputs/changelogBeta.md"
         groups = "continuous-deployment"
     }
 


### PR DESCRIPTION
…bution

This commit fixes an issue where Firebase App Distribution was not using the correct file extension for the release
 notes.

The `releaseNotesFile` property in the `firebaseAppDistribution` block has been updated to use the `.md` extension, ensuring the release notes are correctly uploaded.